### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/yjwon0463/ec55e749-853d-4260-bc36-d7312fc53cdc/cf355d26-6683-4974-a048-bfb33e4ce79d/_apis/work/boardbadge/6e73c944-bea4-42dc-9f7b-1f87fd9df616)](https://dev.azure.com/yjwon0463/ec55e749-853d-4260-bc36-d7312fc53cdc/_boards/board/t/cf355d26-6683-4974-a048-bfb33e4ce79d/Microsoft.RequirementCategory)
 # Azure DevOps HOL
 
 This is the source code for Azure DevOps HOL by taking an example of a documentation project.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#8](https://dev.azure.com/yjwon0463/ec55e749-853d-4260-bc36-d7312fc53cdc/_workitems/edit/8). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.